### PR TITLE
Update url query param from auth to authorization header

### DIFF
--- a/src/main/java/org/restonfire/RequestBuilderUtil.java
+++ b/src/main/java/org/restonfire/RequestBuilderUtil.java
@@ -50,7 +50,7 @@ final class RequestBuilderUtil {
 
   private static AsyncHttpClient.BoundRequestBuilder addQueryParamsIfApplicable(AsyncHttpClient.BoundRequestBuilder requestBuilder, String accessToken) {
     if (StringUtil.notNullOrEmpty(accessToken)) {
-      return requestBuilder.addQueryParam("auth", accessToken);
+      return requestBuilder.addQueryParam("access_token", accessToken);
     }
 
     return requestBuilder;

--- a/src/main/java/org/restonfire/RequestBuilderUtil.java
+++ b/src/main/java/org/restonfire/RequestBuilderUtil.java
@@ -50,7 +50,7 @@ final class RequestBuilderUtil {
 
   private static AsyncHttpClient.BoundRequestBuilder addQueryParamsIfApplicable(AsyncHttpClient.BoundRequestBuilder requestBuilder, String accessToken) {
     if (StringUtil.notNullOrEmpty(accessToken)) {
-      return requestBuilder.addQueryParam("access_token", accessToken);
+      return requestBuilder.addHeader("Authorization", "Bearer " + accessToken);
     }
 
     return requestBuilder;


### PR DESCRIPTION
Hello!

Documentation indicates that the access token should be passed via the `access_token` parameter now instead of `auth`:

https://firebase.google.com/docs/database/rest/auth

However, documentation also indicates that the shallow=true param can not be used with any other query parameters.

This PR switches to using the authorization header instead.